### PR TITLE
Update default toggle hotkey to m

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,8 +209,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Auto clicker with configurable hotkeys")
     parser.add_argument(
         "--toggle",
-        default="ctrl+alt+p",
-        help="Hotkey used to start or stop auto-clicking (default: ctrl+alt+p)",
+        default="m",
+        help="Hotkey used to start or stop auto-clicking (default: m)",
     )
     parser.add_argument(
         "--exit",


### PR DESCRIPTION
## Summary
- change the default toggle hotkey to the single-key `m`
- update the CLI help message to describe the new default

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb2551d288332a0a6ceb5fe0583ff